### PR TITLE
Add nominal vs inflation-adjusted projection toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import type { Inputs } from './types';
+import { useState } from 'react';
+import type { Inputs, ProjectionMode } from './types';
 import { defaultInputs } from './engine/defaults';
 import { useLocalStorage, useResetToDefaults } from './hooks/useLocalStorage';
 import { useProjection } from './hooks/useProjection';
@@ -15,21 +16,28 @@ function App() {
     defaultInputs
   );
   const resetToDefaults = useResetToDefaults(defaultInputs, setInputs);
-  const result = useProjection(inputs);
+  const [projectionMode, setProjectionMode] = useState<ProjectionMode>('real');
+  const result = useProjection(inputs, projectionMode);
 
   return (
     <div className={styles.app}>
       <h1 className={styles.title}>Retirement Planner</h1>
       <div className={styles.layout}>
-        <InputPanel inputs={inputs} onChange={setInputs} onReset={resetToDefaults} />
+        <InputPanel
+          inputs={inputs}
+          onChange={setInputs}
+          onReset={resetToDefaults}
+          projectionMode={projectionMode}
+          onModeChange={setProjectionMode}
+        />
         <ExpensePhaseEditor
           phases={inputs.expensePhases}
           onChange={(phases) => setInputs({ ...inputs, expensePhases: phases })}
         />
         <div className={styles.outputs}>
-          <Summary result={result} inputs={inputs} />
-          <BalanceChart rows={result.rows} inputs={inputs} />
-          <ProjectionTable rows={result.rows} inputs={inputs} />
+          <Summary result={result} inputs={inputs} projectionMode={projectionMode} />
+          <BalanceChart rows={result.rows} inputs={inputs} projectionMode={projectionMode} />
+          <ProjectionTable rows={result.rows} inputs={inputs} projectionMode={projectionMode} />
         </div>
       </div>
     </div>

--- a/src/components/BalanceChart.tsx
+++ b/src/components/BalanceChart.tsx
@@ -37,15 +37,19 @@ export default function BalanceChart({ rows, inputs, projectionMode }: Props) {
       <h2>Portfolio Balance Over Time</h2>
       <p className={styles.subtitle}>
         {projectionMode === 'real'
-          ? "All values in today's dollars"
-          : 'All values in nominal (future) dollars'}
+          ? "Inflation-adjusted (today's dollars)"
+          : 'Nominal (future dollars)'}
       </p>
       <ResponsiveContainer width="100%" height={400}>
         <AreaChart data={data} margin={{ top: 10, right: 30, left: 20, bottom: 0 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
           <XAxis dataKey="year" tick={{ fontSize: 12 }} />
           <YAxis
-            tickFormatter={(v: number) => `$${(v / 1000).toFixed(0)}k`}
+            tickFormatter={(v: number) =>
+              Math.abs(v) >= 1_000_000
+                ? `$${(v / 1_000_000).toFixed(1)}M`
+                : `$${(v / 1000).toFixed(0)}k`
+            }
             tick={{ fontSize: 12 }}
             width={70}
           />

--- a/src/components/BalanceChart.tsx
+++ b/src/components/BalanceChart.tsx
@@ -9,16 +9,17 @@ import {
   ReferenceLine,
   Legend,
 } from 'recharts';
-import type { ProjectionRow, Inputs } from '../types';
+import type { ProjectionRow, Inputs, ProjectionMode } from '../types';
 import { formatCurrency } from '../utils/format';
 import styles from './BalanceChart.module.css';
 
 interface Props {
   rows: ProjectionRow[];
   inputs: Inputs;
+  projectionMode: ProjectionMode;
 }
 
-export default function BalanceChart({ rows, inputs }: Props) {
+export default function BalanceChart({ rows, inputs, projectionMode }: Props) {
   const isSingle = inputs.filingStatus === 'single';
   const bothRetiredYear = isSingle
     ? inputs.person1.retirementYear
@@ -34,7 +35,11 @@ export default function BalanceChart({ rows, inputs }: Props) {
   return (
     <div className={styles.wrapper}>
       <h2>Portfolio Balance Over Time</h2>
-      <p className={styles.subtitle}>All values in today's dollars</p>
+      <p className={styles.subtitle}>
+        {projectionMode === 'real'
+          ? "All values in today's dollars"
+          : 'All values in nominal (future) dollars'}
+      </p>
       <ResponsiveContainer width="100%" height={400}>
         <AreaChart data={data} margin={{ top: 10, right: 30, left: 20, bottom: 0 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />

--- a/src/components/InputPanel.tsx
+++ b/src/components/InputPanel.tsx
@@ -1,4 +1,4 @@
-import type { Inputs, PersonInputs } from '../types';
+import type { Inputs, PersonInputs, ProjectionMode } from '../types';
 import NumberInput from './NumberInput';
 import styles from './InputPanel.module.css';
 
@@ -6,9 +6,11 @@ interface Props {
   inputs: Inputs;
   onChange: (inputs: Inputs) => void;
   onReset: () => void;
+  projectionMode: ProjectionMode;
+  onModeChange: (mode: ProjectionMode) => void;
 }
 
-export default function InputPanel({ inputs, onChange, onReset }: Props) {
+export default function InputPanel({ inputs, onChange, onReset, projectionMode, onModeChange }: Props) {
   const updatePerson = (key: 'person1' | 'person2', field: keyof PersonInputs, value: string | number) => {
     onChange({
       ...inputs,
@@ -118,6 +120,29 @@ export default function InputPanel({ inputs, onChange, onReset }: Props) {
             onChange={() => updateField('filingStatus', 'married')}
           />
           Married
+        </label>
+      </div>
+
+      <div className={styles.statusToggle}>
+        <label>
+          <input
+            type="radio"
+            name="projectionMode"
+            value="real"
+            checked={projectionMode === 'real'}
+            onChange={() => onModeChange('real')}
+          />
+          Inflation-Adjusted
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="projectionMode"
+            value="nominal"
+            checked={projectionMode === 'nominal'}
+            onChange={() => onModeChange('nominal')}
+          />
+          Nominal
         </label>
       </div>
 

--- a/src/components/ProjectionTable.module.css
+++ b/src/components/ProjectionTable.module.css
@@ -2,6 +2,12 @@
   margin: 0 0 0.75rem;
 }
 
+.modeLabel {
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: var(--color-text-light);
+}
+
 .tableScroll {
   overflow-x: auto;
   border: 1px solid var(--color-border);

--- a/src/components/ProjectionTable.tsx
+++ b/src/components/ProjectionTable.tsx
@@ -1,13 +1,14 @@
-import type { ProjectionRow, Inputs } from '../types';
+import type { ProjectionRow, Inputs, ProjectionMode } from '../types';
 import { formatCurrency } from '../utils/format';
 import styles from './ProjectionTable.module.css';
 
 interface Props {
   rows: ProjectionRow[];
   inputs: Inputs;
+  projectionMode: ProjectionMode;
 }
 
-export default function ProjectionTable({ rows, inputs }: Props) {
+export default function ProjectionTable({ rows, inputs, projectionMode }: Props) {
   const isSingle = inputs.filingStatus === 'single';
   const bothRetiredYear = isSingle
     ? inputs.person1.retirementYear
@@ -15,7 +16,12 @@ export default function ProjectionTable({ rows, inputs }: Props) {
 
   return (
     <div className={styles.wrapper}>
-      <h2>Year-by-Year Projection</h2>
+      <h2>
+        Year-by-Year Projection{' '}
+        <span className={styles.modeLabel}>
+          ({projectionMode === 'real' ? 'inflation-adjusted' : 'nominal dollars'})
+        </span>
+      </h2>
       <div className={styles.tableScroll}>
         <table className={styles.table}>
           <thead>

--- a/src/components/ProjectionTable.tsx
+++ b/src/components/ProjectionTable.tsx
@@ -19,7 +19,7 @@ export default function ProjectionTable({ rows, inputs, projectionMode }: Props)
       <h2>
         Year-by-Year Projection{' '}
         <span className={styles.modeLabel}>
-          ({projectionMode === 'real' ? 'inflation-adjusted' : 'nominal dollars'})
+          ({projectionMode === 'real' ? "inflation-adjusted" : "nominal"})
         </span>
       </h2>
       <div className={styles.tableScroll}>

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -1,13 +1,14 @@
-import type { ProjectionResult, Inputs } from '../types';
+import type { ProjectionResult, Inputs, ProjectionMode } from '../types';
 import { formatCurrency, formatPercent } from '../utils/format';
 import styles from './Summary.module.css';
 
 interface Props {
   result: ProjectionResult;
   inputs: Inputs;
+  projectionMode: ProjectionMode;
 }
 
-export default function Summary({ result, inputs }: Props) {
+export default function Summary({ result, inputs, projectionMode }: Props) {
   const { rows, depletionYear, finalBalance } = result;
 
   if (rows.length === 0) {
@@ -68,9 +69,13 @@ export default function Summary({ result, inputs }: Props) {
         </div>
 
         <div className={styles.card}>
-          <span className={styles.label}>Real Returns</span>
+          <span className={styles.label}>
+            {projectionMode === 'real' ? 'Real Returns' : 'Nominal Returns'}
+          </span>
           <span className={styles.value}>
-            {formatPercent(realPreRetGrowth)} / {formatPercent(realPostRetGrowth)}
+            {projectionMode === 'real'
+              ? `${formatPercent(realPreRetGrowth)} / ${formatPercent(realPostRetGrowth)}`
+              : `${formatPercent(inputs.preRetNominalGrowth)} / ${formatPercent(inputs.postRetNominalGrowth)}`}
           </span>
           <span className={styles.detail}>pre / post retirement</span>
         </div>

--- a/src/hooks/useProjection.ts
+++ b/src/hooks/useProjection.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
-import type { Inputs, ProjectionResult } from '../types';
+import type { Inputs, ProjectionResult, ProjectionMode } from '../types';
 import { runProjection } from '../engine/projection';
 
-export function useProjection(inputs: Inputs): ProjectionResult {
-  return useMemo(() => runProjection(inputs), [inputs]);
+export function useProjection(inputs: Inputs, mode: ProjectionMode = 'real'): ProjectionResult {
+  return useMemo(() => runProjection(inputs, mode), [inputs, mode]);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,8 @@ export interface ProjectionRow {
   depleted: boolean;
 }
 
+export type ProjectionMode = 'real' | 'nominal';
+
 export interface ProjectionResult {
   rows: ProjectionRow[];
   depletionYear: number | null;


### PR DESCRIPTION
## Summary
- Adds a `ProjectionMode` toggle (Inflation-Adjusted / Nominal) to the input panel, defaulting to inflation-adjusted
- In nominal mode, growth rates are used as-is and all dollar-denominated inputs (contributions, pension, SS, expenses) are inflated by a cumulative factor each year
- Output labels in Summary, BalanceChart, and ProjectionTable update to reflect the active mode
- Adds 5 test cases covering nominal growth rates, inflated contributions/expenses/income, and default mode behavior

Closes #3

## Test plan
- [x] All 39 tests pass (`npm run test`)
- [x] Build succeeds (`npm run build`)
- [x] Lint clean (`npm run lint`)
- [ ] Manual: toggle between modes and verify table/chart values update correctly
- [ ] Manual: verify default is inflation-adjusted on fresh load

🤖 Generated with [Claude Code](https://claude.com/claude-code)